### PR TITLE
add json publish method

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -57,6 +57,10 @@ Response.prototype.publish = function (message, callback) {
     return this;
 };
 
+Response.prototype.publishJSON = function(message, callback) {
+    return this.publish(JSON.stringify(message), callback);
+};
+
 Response.prototype._finish = function () {
     this.emit('finish');
 };


### PR DESCRIPTION
Just as express has `res.json()`, it would be nice to have a publish method for json